### PR TITLE
Fix version editing for XML multi-line dependencies

### DIFF
--- a/Minetec.Core.Toolset.Upgrader/Program.cs
+++ b/Minetec.Core.Toolset.Upgrader/Program.cs
@@ -40,21 +40,23 @@ namespace Minetec.Core.Toolset.Upgrader
                     var changed = false;
                     var lines = File.ReadAllLines(csproj).ToArray();
 
-                    var state = 0;      // seek "PackageReference..."
-                    var lino = 0;
-                    while (lino < lines.Count())
+                    for (var lino = 0;  lino < lines.Count(); lino++)
                     {
                         var line = lines[lino];
-                        if (state == 0 && line.Trim().StartsWith("<PackageReference Include=\"Minetec")) state = 1;
-                        if (state == 1 && line.Contains("Version"))
+                        if (line.Trim().StartsWith("<PackageReference Include=\"Minetec"))
                         {
-                            line = Regex.Replace(line, "Version=\"([^\"])*\"", $"Version=\"{targetVersion}\"");
-                            line = Regex.Replace(line, "<Version>([^<])*<", $"<Version>{targetVersion}<");
-                            lines[lino] = line;
-                            changed = true;
-                            state = 0;
+                            do
+                            {
+                                if (line.Contains("Version"))
+                                {
+                                    line = Regex.Replace(line, "Version=\"([^\"])*\"", $"Version=\"{targetVersion}\"");
+                                    line = Regex.Replace(line, "<Version>([^<])*<", $"<Version>{targetVersion}<");
+                                    lines[lino] = line;
+                                    changed = true;
+                                    break;
+                                }
+                            } while (lino++ < lines.Count());
                         }
-                        lino++;
                     }
 
                     if (changed)

--- a/Minetec.Core.Toolset.Upgrader/Program.cs
+++ b/Minetec.Core.Toolset.Upgrader/Program.cs
@@ -55,7 +55,7 @@ namespace Minetec.Core.Toolset.Upgrader
                                     changed = true;
                                     break;
                                 }
-                            } while (lino++ < lines.Count());
+                            } while (++lino < lines.Count());
                         }
                     }
 

--- a/Minetec.Core.Toolset.Upgrader/Program.cs
+++ b/Minetec.Core.Toolset.Upgrader/Program.cs
@@ -47,6 +47,7 @@ namespace Minetec.Core.Toolset.Upgrader
                         {
                             do
                             {
+                                line = lines[lino];
                                 if (line.Contains("Version"))
                                 {
                                     line = Regex.Replace(line, "Version=\"([^\"])*\"", $"Version=\"{targetVersion}\"");


### PR DESCRIPTION
* scans for the "PackageReference" verb and than scans lines for the matching version attribute/string
* now supports both Core and Framework style XML
